### PR TITLE
Fix handle isometric asset imports properly

### DIFF
--- a/assets/asset_config.yaml
+++ b/assets/asset_config.yaml
@@ -1,3 +1,7 @@
+
+# search in a prefix path within all asset packs.
+# values for kenney.nl iso packs: Isometric, Angle (top down)
+prefix: Isometric
 assets:
   walls:
     - stoneWall

--- a/tools/extract_assets.py
+++ b/tools/extract_assets.py
@@ -17,7 +17,7 @@ Example:
 import os
 import re
 import yaml
-from utils import write_yaml, extract_zip
+from utils import write_yaml, extract_zip, load_yaml, save_file
 
 ASSETS_YAML_PATH = '../build/assets.yaml'
 ASSETS_DIR = '../build/assets'
@@ -77,6 +77,9 @@ def summarize_asset_pack(path, asset_pack_name, target_dir=ASSETS_DIR):
     Returns:
         (<asset-pack-name>, <dict-listing-all-sprite-assets-found>)
     """
+    asset_config = load_yaml('../assets/asset_config.yaml')
+    if 'prefix' in asset_config:
+        path = os.path.join(path, asset_config['prefix'])
     image_files = [
         os.path.join(root, file)
         for root, dirs, files in os.walk(path)
@@ -97,8 +100,8 @@ def summarize_asset_pack(path, asset_pack_name, target_dir=ASSETS_DIR):
             iso_tiles[name][direction] = path
 
     assets = {'tiles': iso_tiles}
-    with open(os.path.join(target_dir, asset_pack_name + '.yaml'), 'w') as f:
-        f.write(yaml.dump(assets))
+
+    write_yaml(os.path.join(target_dir, asset_pack_name + '.yaml'), assets)
     return asset_pack_name, assets
 
 

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -89,8 +89,10 @@ def save_file(path, data):
 
     basedir = os.path.split(path)[0]
     if not os.path.exists(basedir):
+        print("generating missing directories: '%s'" % basedir)
         os.makedirs(basedir)
 
+    print("saving '%s'" % path)
     with open(path, 'w') as f:
         f.write(data)
 


### PR DESCRIPTION
Fixes isometric asset imports on linux, and lets users switch to using Angle (ie. top down) assets by changing a line in asset_config.yaml